### PR TITLE
git checkout with peco

### DIFF
--- a/conf.d/fish-peco.fish
+++ b/conf.d/fish-peco.fish
@@ -1,5 +1,6 @@
 alias repo="peco_select_ghq"
 alias r="peco_select_ghq"
+alias gck="peco-git-checkout"
 
 # See details on https://fishshell.com/docs/current/cmds/bind.html
 # Activate when insert mode along fish_vi_key_bindings.

--- a/functions/peco_select_git_branch.fish
+++ b/functions/peco_select_git_branch.fish
@@ -1,0 +1,13 @@
+function peco-git-checkout
+   git branch -a | peco | tr -d ' ' | read branch
+   echo $branch
+   if [ $branch ]
+       if contains $branch "remotes/"
+           set -l b (echo $branch | awk -F'/' '{print $3}')
+           git checkout -b $b $branch
+       else
+           git checkout $branch
+       end
+   end
+   commandline -f repaint
+end


### PR DESCRIPTION
### Added
- `peco` is used to git-checkout an existing branch.
- reference: https://www.shigemk2.com/entry/git_checkout_peco_fish