### PR TITLE
Visit a recent directory with `peco`

### DIFF
--- a/functions/peco_select_recent_directory.fish
+++ b/functions/peco_select_recent_directory.fish
@@ -8,7 +8,7 @@ function peco_select_recent_directory
   # ^ is string head
   # [0-9]\+ is multiple digits
   # \s\+ is multiple spaces
-  z -l | sed 's/^[0-9]\+\s\+//' | peco --prompt="cdr >" $peco_flags | read line
+  z -l | sed 's/^[0-9.]\+\s\+//' | peco --prompt="cdr >" $peco_flags | read line
 
   if test $line
     cd $line


### PR DESCRIPTION
### FIxed
- The list of recently visited directories is parsed correctly.